### PR TITLE
chore(dependencies): remove luxon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "costflow",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1121,9 +1121,9 @@
       }
     },
     "dayjs": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.16.tgz",
-      "integrity": "sha512-XPmqzWz/EJiaRHjBqSJ2s6hE/BUoCIHKgdS2QPtTQtKcS9E4/Qn0WomoH1lXanWCzri+g7zPcuNV4aTZ8PMORQ=="
+      "version": "1.8.36",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.36.tgz",
+      "integrity": "sha512-3VmRXEtw7RZKAf+4Tv1Ym9AGeo8r8+CjDi26x+7SYQil1UqtqdaokhzoEJohqlzt0m5kacJSDhJQkG/LWhpRBw=="
     },
     "debug": {
       "version": "2.6.9",
@@ -2938,11 +2938,6 @@
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
-    },
-    "luxon": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.16.0.tgz",
-      "integrity": "sha512-qaqB+JwpGwtl7UbIXng3A/l4W/ySBr8drQvwtMLZBMiLD2V+0fEnPWMrs+UjnIy9PsktazQaKvwDUCLzoWz0Hw=="
     },
     "make-dir": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
   },
   "dependencies": {
     "axios": "^0.19.0",
-    "dayjs": "^1.8.16",
-    "luxon": "^1.16.0",
+    "dayjs": "^1.8.36",
     "squirrelly": "^7.8.0"
   },
   "devDependencies": {

--- a/src/alphavantage.js
+++ b/src/alphavantage.js
@@ -1,5 +1,10 @@
 const axios = require('axios')
-var { DateTime } = require('luxon')
+const dayjs = require('dayjs')
+
+var utc = require('dayjs/plugin/utc') // dependent on utc plugin
+var timezone = require('dayjs/plugin/timezone')
+dayjs.extend(utc)
+dayjs.extend(timezone)
 
 const exchange = function (key, from, to) {
   return new Promise(function (resolve, reject) {
@@ -14,7 +19,7 @@ const exchange = function (key, from, to) {
             const data = response.data['Realtime Currency Exchange Rate']
             const result = {
               rate: Number(data['5. Exchange Rate']),
-              updatedAt: DateTime.fromISO(data['6. Last Refreshed'].replace(' ', 'T'), { zone: response.data['7. Time Zone'] }).ts
+              updatedAt: dayjs.tz(data['6. Last Refreshed'].replace(' ', 'T'), response.data['7. Time Zone']).valueOf()
             }
             resolve(result)
           }

--- a/src/parser.js
+++ b/src/parser.js
@@ -2,12 +2,17 @@
   Costflow Syntax: https://docs.costflow.io/syntax/
 */
 
-const { DateTime } = require('luxon')
 const dayjs = require('dayjs')
 const engine = require('./template-engine')
 const { currencyList, currencyReg } = require('../config/currency-codes')
 const { cryptoList } = require('../config/crypto-currency-codes')
 const alphavantage = require('./alphavantage')
+
+var utc = require('dayjs/plugin/utc') // dependent on utc plugin
+var timezone = require('dayjs/plugin/timezone')
+dayjs.extend(utc)
+dayjs.extend(timezone)
+
 
 const parseTransaction = function (transaction, config, defaultSign, calculatedAmount, calculatedCommodity) {
   transaction = transaction.trim()
@@ -82,7 +87,8 @@ const parser = async function (input, config) {
 
   // date
   const ymdReg = /^(\d{4})-(\d{2})-(\d{2})\s/g
-  const today = config.timezone ? DateTime.local().setZone(config.timezone).toFormat('y-LL-dd') : DateTime.local().toFormat('y-LL-dd')
+  const now = config.timezone ? dayjs().tz(config.timezone) : dayjs()
+  const today = now.format('YYYY-MM-DD')
   let date = input.match(ymdReg) && input.match(ymdReg).length ? input.match(ymdReg)[0].trim() : null
   input = date ? input.slice(date.length).trim() : input.trim()
 
@@ -367,10 +373,9 @@ const parser = async function (input, config) {
       }
 
       if (config.insertTime === 'metadata') {
-        const now = DateTime.local().setZone(config.timezone)
-        let timeOrDatetime = now.toFormat('HH:mm:ss')
-        if (now.toFormat('y-LL-dd') !== date) {
-          timeOrDatetime = now.toFormat('y-LL-dd HH:mm:ss')
+        let timeOrDatetime = now.format('HH:mm:ss')
+        if (dayjs().format('YYYY-MM-DD') !== date) {
+          timeOrDatetime = now.format('YYYY-MM-DD HH:mm:ss')
         }
         output += '\n'
         output += Array(config.indent).fill(' ').join('')


### PR DESCRIPTION
DayJS supports timezones now, so simplify dependencies and drop luxon.

Tests are passing, and ad-hoc `console.log` manual testing also didn't raise any concerns.